### PR TITLE
Bump Bottlerocket versions to latest release

### DIFF
--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
@@ -1,19 +1,19 @@
 1-25:
-    ami-release-version: v1.19.1
-    ova-release-version: v1.19.1
-    raw-release-version: v1.19.1
+    ami-release-version: v1.19.2
+    ova-release-version: v1.19.2
+    raw-release-version: v1.19.2
 1-26:
-    ami-release-version: v1.19.1
-    ova-release-version: v1.19.1
-    raw-release-version: v1.19.1
+    ami-release-version: v1.19.2
+    ova-release-version: v1.19.2
+    raw-release-version: v1.19.2
 1-27:
-    ami-release-version: v1.19.1
-    ova-release-version: v1.19.1
-    raw-release-version: v1.19.1
+    ami-release-version: v1.19.2
+    ova-release-version: v1.19.2
+    raw-release-version: v1.19.2
 1-28:
-    ami-release-version: v1.19.1
-    ova-release-version: v1.19.1
-    raw-release-version: v1.19.1
+    ami-release-version: v1.19.2
+    ova-release-version: v1.19.2
+    raw-release-version: v1.19.2
 1-29:
-    ami-release-version: v1.19.1
-    ova-release-version: v1.19.1
+    ami-release-version: v1.19.2
+    ova-release-version: v1.19.2


### PR DESCRIPTION
This PR bumps kubernetes-sigs/image-builder to the latest Git revision, along with other updates such as Go version, checksums and attribution files.

[Compare changes](https://github.com/kubernetes-sigs/image-builder/compare/v0.1.24...v0.1.24)
[Release notes](https://github.com/kubernetes-sigs/image-builder/releases/v0.1.24)

/hold
/area dependencies

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.